### PR TITLE
Use latest java client (0.5.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,38 +2,38 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>data-model-migration</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.0.3-SNAPSHOT</version>
   <name>Data Model Migration</name>
   
   <dependencies>
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
       <artifactId>pass-client-api</artifactId>
-      <version>0.5.1</version>
+      <version>0.5.2</version>
     </dependency>
     
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
       <artifactId>pass-model</artifactId>
-      <version>0.5.1</version>
+      <version>0.5.2</version>
     </dependency>
     
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
       <artifactId>pass-data-client</artifactId>
-      <version>0.5.1</version>
+      <version>0.5.2</version>
     </dependency>
     
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
       <artifactId>pass-status-service</artifactId>
-      <version>0.5.1</version>
+      <version>0.5.2</version>
     </dependency>
     
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
       <artifactId>pass-client-shaded-v2_3</artifactId>
-      <version>0.5.1</version>
+      <version>0.5.2</version>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
The latest `java-fedora-client` changes the status calculation code so that it doesn't throw an exception when calculating status for Submissions without a repository - as is the case when there are web-linked repositories only.

Increment the version to 0.0.3-SNAPSHOT